### PR TITLE
Update README with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,10 @@ LTR algorithms can be categorized into three main approaches:
 
 ### 2020
 
+- Khattab, Omar, and Matei Zaharia. "[ColBERT: Efficient and Effective Passage Search via Contextualized Late Interaction over BERT.](https://arxiv.org/pdf/2004.12832.pdf)" Proceedings of the 43rd International ACM SIGIR Conference on Research and Development in Information Retrieval. 2020. [code](https://github.com/stanford-futuredata/ColBERT)
+- Karpukhin, Vladimir, et al. "[Dense Passage Retrieval for Open-Domain Question Answering.](https://arxiv.org/pdf/2004.04906.pdf)" Proceedings of the 2020 Conference on Empirical Methods in Natural Language Processing (EMNLP). 2020. [code](https://github.com/facebookresearch/DPR)
 - Qu, Chen, et al. "[Contextual Re-Ranking with Behavior Aware Transformers.](http://ciir-publications.cs.umass.edu/getpdf.php?id=1383)" Proceedings of the 43rd International ACM SIGIR Conference on Research and Development in Information Retrieval. 2020.
-- MacAvaney, Sean, et al. "[Efficient Document Re-Ranking for Transformers by Precomputing Term Representations.](https://arxiv.org/pdf/2004.14255.pdf)" The 43st International ACM SIGIR Conference on Research & Development in Information Retrieval. 2020. [code](https://github.com/Georgetown-IR-Lab/prettr-neural-ir)?
+- MacAvaney, Sean, et al. "[Efficient Document Re-Ranking for Transformers by Precomputing Term Representations.](https://arxiv.org/pdf/2004.14255.pdf)" The 43st International ACM SIGIR Conference on Research & Development in Information Retrieval. 2020. [code](https://github.com/Georgetown-IR-Lab/prettr-neural-ir)
 - Zhuang, Honglei, et al. "[Feature transformation for neural ranking models.](https://storage.googleapis.com/pub-tools-public-publication-data/pdf/03d9dbc56c3d1b19a611043a4cb72e227ebba249.pdf)" Proceedings of the 43rd International ACM SIGIR Conference on Research and Development in Information Retrieval. 2020.
 - Lucchese, Claudio, et al. "[Query-level Early Exit for Additive Learning-to-Rank Ensembles.](https://arxiv.org/pdf/2004.14641.pdf)" The 43st International ACM SIGIR Conference on Research & Development in Information Retrieval. 2020.
 - Bevendorff, Maik Fröbe1 Janek, et al. "[Sampling Bias Due to Near-Duplicates in Learning to Rank.](https://webis.de/downloads/publications/papers/webis_2020d.pdf)" The 43st International ACM SIGIR Conference on Research & Development in Information Retrieval. 2020. [code](https://github.com/webis-de/SIGIR-20)
@@ -143,12 +145,24 @@ LTR algorithms can be categorized into three main approaches:
 ### 2021
 
 - Qin, Zhen, et al. "[Are Neural Rankers still Outperformed by Gradient Boosted Decision Trees?](https://openreview.net/pdf?id=Ut1vF_q_vC)" International Conference on Learning Representations (ICLR). 2021.
+- Formal, Thibault, Benjamin Piwowarski, and Stéphane Clinchant. "[SPLADE: Sparse Lexical and Expansion Model for First Stage Ranking.](https://arxiv.org/pdf/2107.05720.pdf)" Proceedings of the 44th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2021. [code](https://github.com/naver/splade)
+- Swezey, Robin, et al. "[PiRank: Scalable Learning To Rank via Differentiable Sorting.](https://arxiv.org/pdf/2012.06731.pdf)" Advances in Neural Information Processing Systems (NeurIPS). 2021.
+- Oosterhuis, Harrie. "[Computationally Efficient Optimization of Plackett-Luce Ranking Models for Relevance and Fairness.](https://arxiv.org/pdf/2105.05067.pdf)" Proceedings of the 44th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2021. (Best Paper Award)
+- Hofstätter, Sebastian, et al. "[Efficiently Teaching an Effective Dense Retriever with Balanced Topic Aware Sampling.](https://arxiv.org/pdf/2104.06967.pdf)" Proceedings of the 44th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2021.
+- Gao, Luyu, Zhuyun Dai, and Jamie Callan. "[Rethink Training of BERT Rerankers in Multi-Stage Retrieval Pipeline.](https://arxiv.org/pdf/2101.08751.pdf)" European Conference on Information Retrieval (ECIR). 2021.
+- MacAvaney, Sean, Franco Maria Nardini, and Raffaele Perego. "[A Systematic Evaluation of Transfer Learning and Pseudo-labeling with BERT-based Ranking Models.](https://arxiv.org/pdf/2106.03699.pdf)" Proceedings of the 44th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2021.
+- Formal, Thibault, et al. "[A White Box Analysis of ColBERT.](https://arxiv.org/pdf/2101.05405.pdf)" European Conference on Information Retrieval (ECIR). 2021.
 
 ### 2022
 
+- Santhanam, Keshav, et al. "[ColBERTv2: Effective and Efficient Retrieval via Lightweight Late Interaction.](https://arxiv.org/pdf/2112.01488.pdf)" Proceedings of the 2022 Conference of the North American Chapter of the Association for Computational Linguistics (NAACL). 2022. [code](https://github.com/stanford-futuredata/ColBERT)
+- Formal, Thibault, et al. "[From Distillation to Hard Negative Sampling: Making Sparse Neural IR Models More Effective.](https://arxiv.org/pdf/2205.04733.pdf)" Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2022. [code](https://github.com/naver/splade)
 - Pobrotyn, Przemysław, et al. "[Learning Neural Ranking Models Online from Implicit User Feedback.](https://arxiv.org/pdf/2204.09118.pdf)" Proceedings of the ACM Web Conference 2022. 2022.
 - Khosla, Sopan, and Vinay Setty. "[Risk-Sensitive Deep Neural Learning to Rank.](https://dl.acm.org/doi/abs/10.1145/3477495.3532056)" Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2022.
-- Rama Kumar Pasumarthi, et al. "[Learning-to-Rank at the Speed of Sampling.](https://dl.acm.org/doi/10.1145/3477495.3531842)" Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2022.
+- Pasumarthi, Rama Kumar, et al. "[Learning-to-Rank at the Speed of Sampling.](https://dl.acm.org/doi/10.1145/3477495.3531842)" Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2022.
+- Hofstätter, Sebastian, et al. "[Ensemble Distillation for BERT-Based Ranking Models.](https://arxiv.org/pdf/2107.11912.pdf)" Proceedings of the 2021 ACM SIGIR International Conference on Theory of Information Retrieval (ICTIR). 2021.
+- Lassance, Carlos, et al. "[Learned Token Pruning in Contextualized Late Interaction over BERT (ColBERT).](https://arxiv.org/pdf/2203.07785.pdf)" Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2022.
+- Yang, Tao, et al. "[Can clicks be both labels and features? Unbiased Behavior Feature Collection and Uncertainty-aware Learning to Rank.](https://arxiv.org/pdf/2203.11063.pdf)" Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2022.
 
 ### 2023
 
@@ -158,9 +172,11 @@ LTR algorithms can be categorized into three main approaches:
 
 ### 2024
 
+- Khramtsova, Ekaterina, et al. "[Leveraging LLMs for Unsupervised Dense Retriever Ranking.](https://arxiv.org/pdf/2402.04853.pdf)" Proceedings of the 47th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2024. (Best Paper Award)
 - Borisyuk, Fedor, et al. "[LiRank: Industrial Large Scale Ranking Models at LinkedIn.](https://arxiv.org/pdf/2402.06859.pdf)" Proceedings of the 30th ACM SIGKDD Conference on Knowledge Discovery and Data Mining. 2024.
 - Huang, Xuyang, et al. "[Unbiased Learning-to-Rank Needs Unconfounded Propensity Estimation.](https://dl.acm.org/doi/10.1145/3626772.3657772)" Proceedings of the 47th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2024.
 - Jagerman, Rolf, et al. "[Unbiased Learning to Rank: On Recent Advances and Practical Applications.](https://dl.acm.org/doi/abs/10.1145/3616855.3636451)" Proceedings of the 17th ACM International Conference on Web Search and Data Mining. 2024.
+- Liu, Yu-An, et al. "[Multi-granular Adversarial Attacks against Black-box Neural Ranking Models.](https://arxiv.org/pdf/2404.01574.pdf)" Proceedings of the 47th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2024.
 
 ### 2025
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
 # Learning To Rank (LTR)
 
+A curated list of research papers, software, datasets, and resources for Learning to Rank (LTR), also known as machine-learned ranking.
+
+## What is Learning to Rank?
+
+Learning to Rank (LTR) is a machine learning approach for constructing ranking models from training data. LTR has been particularly successful in information retrieval, web search, and recommendation systems where the goal is to rank a set of items according to their relevance to a given query.
+
+### LTR Approaches
+
+LTR algorithms can be categorized into three main approaches:
+
+- **Pointwise Approach**: Treats ranking as a regression or classification problem, predicting a relevance score for each document independently.
+  - Examples: McRank, Prank, OC SVM
+
+- **Pairwise Approach**: Focuses on learning the relative order between pairs of documents. The goal is to minimize the number of incorrectly ordered pairs.
+  - Examples: RankNet, RankBoost, RankSVM, LambdaRank, LambdaMART
+
+- **Listwise Approach**: Directly optimizes ranking metrics (e.g., NDCG, MAP) by considering the entire list of documents.
+  - Examples: ListNet, ListMLE, AdaRank, SoftRank, LambdaMART
+
+## Table of Contents
+
+- [Papers](#papers)
+  - [2003-2020](#2003)
+  - [2021-2025](#2021)
+- [Software](#software)
+- [Dataset](#dataset)
+- [Others](#others)
+
 ## Papers
 
 ### 2003
@@ -112,35 +140,94 @@
 - Lucchese, Claudio, et al. "[Query-level Early Exit for Additive Learning-to-Rank Ensembles.](https://arxiv.org/pdf/2004.14641.pdf)" The 43st International ACM SIGIR Conference on Research & Development in Information Retrieval. 2020.
 - Bevendorff, Maik Fröbe1 Janek, et al. "[Sampling Bias Due to Near-Duplicates in Learning to Rank.](https://webis.de/downloads/publications/papers/webis_2020d.pdf)" The 43st International ACM SIGIR Conference on Research & Development in Information Retrieval. 2020. [code](https://github.com/webis-de/SIGIR-20)
 
+### 2021
+
+- Qin, Zhen, et al. "[Are Neural Rankers still Outperformed by Gradient Boosted Decision Trees?](https://openreview.net/pdf?id=Ut1vF_q_vC)" International Conference on Learning Representations (ICLR). 2021.
+
+### 2022
+
+- Pobrotyn, Przemysław, et al. "[Learning Neural Ranking Models Online from Implicit User Feedback.](https://arxiv.org/pdf/2204.09118.pdf)" Proceedings of the ACM Web Conference 2022. 2022.
+- Khosla, Sopan, and Vinay Setty. "[Risk-Sensitive Deep Neural Learning to Rank.](https://dl.acm.org/doi/abs/10.1145/3477495.3532056)" Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2022.
+- Rama Kumar Pasumarthi, et al. "[Learning-to-Rank at the Speed of Sampling.](https://dl.acm.org/doi/10.1145/3477495.3531842)" Proceedings of the 45th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2022.
+
+### 2023
+
+- Buyl, Maarten, et al. "[RankFormer: Listwise Learning-to-Rank Using Listwide Labels.](https://arxiv.org/pdf/2306.17104.pdf)" Proceedings of the 29th ACM SIGKDD Conference on Knowledge Discovery and Data Mining. 2023.
+- Ai, Qingyao, Xuanhui Wang, and Michael Bendersky. "[Metric-agnostic Ranking Optimization.](https://dl.acm.org/doi/10.1145/3539618.3591915)" Proceedings of the 46th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2023.
+- Zhao, Haiyuan, et al. "[Unbiased Top-k Learning to Rank with Causal Likelihood Decomposition.](https://dl.acm.org/doi/10.1145/3624918.3625319)" Proceedings of the Annual International ACM SIGIR Conference on Research and Development in Information Retrieval in the Asia Pacific Region (SIGIR-AP). 2023.
+
+### 2024
+
+- Borisyuk, Fedor, et al. "[LiRank: Industrial Large Scale Ranking Models at LinkedIn.](https://arxiv.org/pdf/2402.06859.pdf)" Proceedings of the 30th ACM SIGKDD Conference on Knowledge Discovery and Data Mining. 2024.
+- Huang, Xuyang, et al. "[Unbiased Learning-to-Rank Needs Unconfounded Propensity Estimation.](https://dl.acm.org/doi/10.1145/3626772.3657772)" Proceedings of the 47th International ACM SIGIR Conference on Research and Development in Information Retrieval. 2024.
+- Jagerman, Rolf, et al. "[Unbiased Learning to Rank: On Recent Advances and Practical Applications.](https://dl.acm.org/doi/abs/10.1145/3616855.3636451)" Proceedings of the 17th ACM International Conference on Web Search and Data Mining. 2024.
+
+### 2025
+
+- Wang, Qingyu, et al. "[From Features to Transformers: Redefining Ranking for Scalable Impact.](https://arxiv.org/abs/2502.03417)" arXiv preprint arXiv:2502.03417. 2025.
+
 ## Software
 
-- [Support Vector Machine for Ranking](http://www.cs.cornell.edu/people/tj/svm_light/svm_rank.html)
-- [Support Vector Machine for Optimizing Mean Average Precision](http://projects.yisongyue.com/svmmap/)
-- [TensorFlow Ranking](https://github.com/tensorflow/ranking)
-- [LambdaRank Example on LightGBM](https://github.com/Microsoft/LightGBM/tree/master/examples/lambdarank)
-- [Chainer implementation of RankNet](https://github.com/kzkadc/ranknet)
-- [jforests](https://github.com/yasserg/jforests)
-- [ListNet](https://sourceforge.net/projects/listnet/)
-- [ListMLE](https://sourceforge.net/projects/listmle/)
-- [Metric Learning to Rank](https://github.com/bmcfee/mlr)
-- [Lerot](https://bitbucket.org/ilps/lerot/src/master/)
-- [xapian-letor](https://github.com/xapian/xapian/tree/master/xapian-letor)
-- [OpenNIR](https://opennir.net/)
-- [metarank](https://www.metarank.ai/)
+### Classical LTR Libraries
+
+- [Support Vector Machine for Ranking](http://www.cs.cornell.edu/people/tj/svm_light/svm_rank.html) - SVM^rank implementation
+- [Support Vector Machine for Optimizing Mean Average Precision](http://projects.yisongyue.com/svmmap/) - SVM-MAP implementation
+- [jforests](https://github.com/yasserg/jforests) - Java implementation of gradient boosted trees for LTR
+- [ListNet](https://sourceforge.net/projects/listnet/) - Listwise approach implementation
+- [ListMLE](https://sourceforge.net/projects/listmle/) - List Maximum Likelihood Estimation
+- [Metric Learning to Rank](https://github.com/bmcfee/mlr) - Python implementation
+- [Lerot](https://bitbucket.org/ilps/lerot/src/master/) - Online learning to rank framework
+- [xapian-letor](https://github.com/xapian/xapian/tree/master/xapian-letor) - LTR module for Xapian search engine
+
+### Deep Learning & Modern LTR Libraries
+
+- [TensorFlow Ranking](https://github.com/tensorflow/ranking) - Scalable TensorFlow library for LTR
+- [LambdaRank Example on LightGBM](https://github.com/Microsoft/LightGBM/tree/master/examples/lambdarank) - LambdaRank with gradient boosting
+- [Chainer implementation of RankNet](https://github.com/kzkadc/ranknet) - Neural network approach
+- [OpenNIR](https://opennir.net/) - Neural IR research platform
+- [metarank](https://www.metarank.ai/) - Modern LTR for e-commerce and recommendations
+- [Transformer Rankers](https://github.com/Guzpenha/transformer_rankers) - Library for ranking experiments with transformers
 
 ## Dataset
 
-- [LETOR 3.0/4.0](https://www.microsoft.com/en-us/research/project/letor-learning-rank-information-retrieval/)
-- [MSLR WEB10K/WEB30K](https://www.microsoft.com/en-us/research/project/mslr/)
-- [TREC QA Track Data](https://trec.nist.gov/data/qamain.html)
+- [LETOR 3.0/4.0](https://www.microsoft.com/en-us/research/project/letor-learning-rank-information-retrieval/) - Benchmark datasets for learning to rank research
+- [MSLR WEB10K/WEB30K](https://www.microsoft.com/en-us/research/project/mslr/) - Microsoft Learning to Rank datasets
+- [TREC QA Track Data](https://trec.nist.gov/data/qamain.html) - Question answering and retrieval datasets
+- [Yahoo! Learning to Rank Challenge](https://webscope.sandbox.yahoo.com/) - Large-scale LTR dataset from Yahoo!
 
 ## Others
 
-- [QuickRank](https://github.com/hpclab/quickrank)
-- [ExpediaLearningToRank](https://github.com/arifqodari/ExpediaLearningToRank)
+### Tools and Projects
+
+- [QuickRank](https://github.com/hpclab/quickrank) - Fast learning to rank C++ library
+- [ExpediaLearningToRank](https://github.com/arifqodari/ExpediaLearningToRank) - LTR application for hotel search
+
+### Japanese Resources (日本語リソース)
+
 - [ランク学習（Learning to Rank） Advent Calendar 2018](https://adventar.org/calendars/3357)
 - [DSIRNLP#1 ランキング学習ことはじめ](https://www.slideshare.net/sleepy_yoshi/dsirnlp1)
 - [Learning to rank (LTR) とは何か](https://qiita.com/sugiyamath/items/ba08874490e21a9a3ac1)
 - [SIGIR2011読み会 3: Learning to Rank](https://www.slideshare.net/sleepy_yoshi/sigir2011-3-learning-to-rank)
 - [SIGIR2012勉強会 23: Learning to Rank](https://www.slideshare.net/sleepy_yoshi/sigir2012-23-learning-to-rank)
+
+## Contributing
+
+Contributions are welcome! If you know of any important papers, software, datasets, or resources related to Learning to Rank that are not listed here, please feel free to:
+
+1. Open an issue with the details
+2. Submit a pull request with your additions
+
+When adding papers, please:
+- Include the full citation with authors, title, and venue
+- Add a link to the paper (preferably direct PDF or DOI)
+- Place the paper in the appropriate year section
+- Follow the existing format
+
+## Star History
+
+If you find this repository useful, please consider giving it a star ⭐
+
+## License
+
+This list is provided as-is for educational and research purposes. All linked papers and resources are copyright of their respective authors and publishers.
 


### PR DESCRIPTION
- Add project description and introduction to Learning to Rank
- Add explanation of LTR approaches (pointwise, pairwise, listwise)
- Add table of contents for better navigation
- Add recent papers from 2021-2025 including:
  * Neural ranking and transformer-based methods
  * Unbiased learning to rank advances
  * Industrial-scale ranking systems (LinkedIn LiRank)
- Reorganize Software section into Classical and Modern categories
- Add new libraries (Transformer Rankers)
- Enhance Dataset section with descriptions
- Reorganize Others section with subsections
- Add Contributing guidelines
- Add License information